### PR TITLE
Add daily sessions stats endpoint

### DIFF
--- a/app/Http/Controllers/RehabController.php
+++ b/app/Http/Controllers/RehabController.php
@@ -216,6 +216,20 @@ class RehabController extends Controller
         return response()->json(['message' => 'Tornato al periodo precedente']);
     }
 
+    public function dailySessions(Request $request)
+    {
+        $user = $request->user();
+
+        $data = $user->rehabSessions()
+            ->selectRaw('DATE(started_at) as date, COUNT(*) as count')
+            ->groupByRaw('DATE(started_at)')
+            ->orderByRaw('DATE(started_at)')
+            ->get()
+            ->map(fn($row) => ['date' => $row->date, 'count' => (int) $row->count]);
+
+        return response()->json($data);
+    }
+
     public function extras()
     {
         return response()->json(RehabExtra::all());

--- a/routes/api.php
+++ b/routes/api.php
@@ -27,6 +27,7 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::get('extra/{id}', 'extraDetail');
 
         Route::post('period/previous', 'goToPreviousPeriod');
+        Route::get('sessions/daily', 'dailySessions');
         Route::post('questionnaire/submit', 'submitAnswers');
         Route::post('session/start', 'startSession');
         Route::post('session/end', 'endSession');


### PR DESCRIPTION
## Summary
- add `dailySessions` endpoint in `RehabController`
- expose GET `/sessions/daily` route

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849983a340483298fdf91a154702f68