### PR TITLE
Enable filtering statistics by user attributes

### DIFF
--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -9,43 +9,57 @@ use App\Models\RehabPeriod;
 use App\Models\RehabSession;
 use App\Models\RehabUserProgress;
 use App\Models\User;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
 class DashboardController extends Controller
 {
-    public function index()
+    public function index(Request $request)
     {
-        // — 1. Utenti
-        $totalUsers = User::where('role', RoleEnum::USER)->count();
+        $ageRange    = $request->input('age_range');
+        $surgeryType = $request->input('surgery_type');
+        $surgeryTime = $request->input('surgery_time');
 
-        $ageDistribution = User::where('role', RoleEnum::USER)
+        $baseUsers = User::where('role', RoleEnum::USER)
+            ->when($ageRange,    fn($q) => $q->whereRaw("JSON_UNQUOTE(JSON_EXTRACT(data, '$.age_range')) = ?", [$ageRange]))
+            ->when($surgeryType, fn($q) => $q->whereRaw("JSON_UNQUOTE(JSON_EXTRACT(data, '$.surgery_type')) = ?", [$surgeryType]))
+            ->when($surgeryTime, fn($q) => $q->whereRaw("JSON_UNQUOTE(JSON_EXTRACT(data, '$.surgery_time')) = ?", [$surgeryTime]));
+
+        $userIds = (clone $baseUsers)->pluck('id');
+
+        // — 1. Utenti
+        $totalUsers = $userIds->count();
+
+        $ageDistribution = (clone $baseUsers)
             ->selectRaw("JSON_UNQUOTE(JSON_EXTRACT(data, '$.age_range')) AS bucket, COUNT(*) AS count")
             ->groupBy('bucket')
             ->pluck('count', 'bucket');
 
-        $surgeryTypeDist = User::where('role', RoleEnum::USER)
+        $surgeryTypeDist = (clone $baseUsers)
             ->selectRaw("JSON_UNQUOTE(JSON_EXTRACT(data, '$.surgery_type')) AS answer, COUNT(*) AS count")
             ->groupBy('answer')
             ->pluck('count','answer');
 
-        $surgeryTimeDist = User::where('role', RoleEnum::USER)
+        $surgeryTimeDist = (clone $baseUsers)
             ->selectRaw("JSON_UNQUOTE(JSON_EXTRACT(data, '$.surgery_time')) AS answer, COUNT(*) AS count")
             ->groupBy('answer')
             ->pluck('count','answer');
 
-        $movementDist = User::where('role', RoleEnum::USER)
+        $movementDist = (clone $baseUsers)
             ->selectRaw("JSON_UNQUOTE(JSON_EXTRACT(data, '$.movement')) AS answer, COUNT(*) AS count")
             ->groupBy('answer')
             ->pluck('count','answer');
 
         // — 2. Pre-calcoli per periodo
         $usersPerPeriod = RehabUserProgress::where('is_active', true)
+            ->whereIn('user_id', $userIds)
             ->join('rehab_periods','rehab_user_progress.rehab_period_id','=','rehab_periods.id')
             ->select('rehab_periods.title', DB::raw('COUNT(*) AS count'))
             ->groupBy('rehab_periods.title')
             ->pluck('count','title');
 
-        $sessionsStats = RehabSession::join('rehab_periods','rehab_sessions.rehab_period_id','=','rehab_periods.id')
+        $sessionsStats = RehabSession::whereIn('rehab_sessions.user_id', $userIds)
+            ->join('rehab_periods','rehab_sessions.rehab_period_id','=','rehab_periods.id')
             ->select(
                 'rehab_periods.title',
                 DB::raw('COUNT(*) AS total'),
@@ -59,13 +73,14 @@ class DashboardController extends Controller
 
         // conteggio questionari inviati = sessioni con almeno 1 risposta
         $questionnairesPerPeriod = RehabAnswer::join('rehab_sessions','rehab_answers.rehab_session_id','=','rehab_sessions.id')
+            ->whereIn('rehab_sessions.user_id', $userIds)
             ->join('rehab_periods','rehab_sessions.rehab_period_id','=','rehab_periods.id')
             ->select('rehab_periods.title', DB::raw('COUNT(DISTINCT rehab_answers.rehab_session_id) AS count'))
             ->groupBy('rehab_periods.title')
             ->pluck('count','title');
 
         // — 3. Costruisco l’array periods
-        $periods = RehabPeriod::orderBy('order')->get()->map(function($period) use ($usersPerPeriod, $sessionsStats, $questionnairesPerPeriod) {
+        $periods = RehabPeriod::orderBy('order')->get()->map(function($period) use ($usersPerPeriod, $sessionsStats, $questionnairesPerPeriod, $userIds) {
             $title        = $period->title;
             $userCount    = $usersPerPeriod->get($title, 0);
             $sessData     = $sessionsStats->get($title, ['total' => 0, 'completed' => 0]);
@@ -89,9 +104,10 @@ class DashboardController extends Controller
                 ? round($perUserAvgs->avg(), 2)
                 : 0;
 
-            // domande + distribuzioni FILTRANDO SOLO SESSIONI COMPLETATE
-            $questions = $period->questions->map(function($q) use ($period) {
+            // domande + distribuzioni filtrando gli utenti
+            $questions = $period->questions->map(function($q) use ($period, $userIds) {
                 $dist = RehabAnswer::join('rehab_sessions','rehab_answers.rehab_session_id','=','rehab_sessions.id')
+                    ->whereIn('rehab_sessions.user_id', $userIds)
                     ->where('rehab_sessions.rehab_period_id', $period->id)
                     ->where('rehab_answers.rehab_question_id', $q->id)
                     ->select('rehab_answers.answer', DB::raw('COUNT(*) as count'))
@@ -119,6 +135,17 @@ class DashboardController extends Controller
             ];
         });
 
+        // opzioni per i filtri (tutte le possibili risposte)
+        $ageOptions = User::where('role', RoleEnum::USER)
+            ->selectRaw("DISTINCT JSON_UNQUOTE(JSON_EXTRACT(data, '$.age_range')) AS val")
+            ->pluck('val');
+        $surgeryTypeOptions = User::where('role', RoleEnum::USER)
+            ->selectRaw("DISTINCT JSON_UNQUOTE(JSON_EXTRACT(data, '$.surgery_type')) AS val")
+            ->pluck('val');
+        $surgeryTimeOptions = User::where('role', RoleEnum::USER)
+            ->selectRaw("DISTINCT JSON_UNQUOTE(JSON_EXTRACT(data, '$.surgery_time')) AS val")
+            ->pluck('val');
+
         // — 4. Torno la view con tutti i dati
         return view('admin.dashboard', compact(
             'totalUsers',
@@ -126,7 +153,13 @@ class DashboardController extends Controller
             'surgeryTypeDist',
             'surgeryTimeDist',
             'movementDist',
-            'periods'
+            'periods',
+            'ageOptions',
+            'surgeryTypeOptions',
+            'surgeryTimeOptions',
+            'ageRange',
+            'surgeryType',
+            'surgeryTime'
         ));
     }
 }

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -82,6 +82,40 @@
 
         {{-- PERIODI TAB --}}
         <div class="tab-pane fade" id="periodi" role="tabpanel">
+            <form method="GET" class="row g-3 align-items-end mb-4">
+                <div class="col-md-3">
+                    <label class="form-label">Fascia d'età</label>
+                    <select name="age_range" class="form-select">
+                        <option value="">Tutte</option>
+                        @foreach($ageOptions as $opt)
+                            <option value="{{ $opt }}" @selected($ageRange === $opt)>{{ $opt }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label">Tipo intervento</label>
+                    <select name="surgery_type" class="form-select">
+                        <option value="">Tutti</option>
+                        @foreach($surgeryTypeOptions as $opt)
+                            <option value="{{ $opt }}" @selected($surgeryType === $opt)>{{ $opt }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label">Tempo dall'intervento</label>
+                    <select name="surgery_time" class="form-select">
+                        <option value="">Tutti</option>
+                        @foreach($surgeryTimeOptions as $opt)
+                            <option value="{{ $opt }}" @selected($surgeryTime === $opt)>{{ $opt }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="col-md-3 d-flex">
+                    <button type="submit" class="btn btn-primary me-2">Filtra</button>
+                    <a href="{{ route('dashboard') }}" class="btn btn-secondary">Reset</a>
+                </div>
+            </form>
+
             <div class="row g-4">
                 @foreach($periods as $idx => $p)
                     <div class="col-12">


### PR DESCRIPTION
## Summary
- allow dashboard filter by registration fields
- display filter options on the statistics tab

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684998436358832987457f670a88b9b9